### PR TITLE
Fix: Use the resource group specified by user for all resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains instructions and template files to deploy an [AiiDAlab]
 * [Create an AiiDAlab deployment on Azure (with AKS)](#create-an-aiidalab-deployment-on-azure-with-aks)
    * [Learn the Terraform basics](#learn-the-terraform-basics)
    * [Configure your environment](#configure-your-environment)
-   * [Configure Azure storage to store Terraform state](#configure-azure-storage-to-store-terraform-state)
+   * [Configure Azure resources](#configure-azure-resources)
    * [Create the AiiDAlab Terraform deployment directory](#create-the-AiiDAlab-terraform-deployment-directory)
    * [Use Terraform to create the deployment](#use-terraform-to-create-the-deployment)
    * [Access and maintain the deployment](#access-and-maintain-the-deployment)
@@ -77,17 +77,17 @@ If you are not familiar with the purpose and basic use of Terraform yet, we reco
    The private and public key should be copied to the `~/.ssh` directory with the names `id_rsa` and `id_rsa.pub`, respectively.
    The private key will eventually provide ssh access to the cluster as the `ubuntu` user.
 
-### 3. Configure Azure storage to store Terraform state
+### 3. Configure Azure resources
 
-Your unit administrator may have already created an Azure storage account to store Terraform state for your unit, in which case please ask them to provide:
+The deployment requires a number of Azure resources to be created in advance:
 
-- The Azure storage account name.
-- The resource group name of the storage account.
-- The name of the container in the storage account to be used by terraform.
+- A resource group: All created resources will be grouped under this group
+- A storage account: An account that can host storage containers
+- A storage container: A container in the storage account that is used to store Terraform state
 
-Otherwise, please follow the instructions [here](https://github.com/MicrosoftDocs/azure-dev-docs/blob/main/articles/terraform/create-k8s-cluster-with-tf-and-aks.md#2-configure-azure-storage-to-store-terraform-state) to create a storage account and a container to store Terraform state.
+See the following links for instructions on how to create a [resource group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/manage-resource-groups-portal), [storage account](#https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal) and [storage container](#https://learn.microsoft.com/en-us/azure/storage/blobs/blob-containers-portal).
 
-The information listed above will be needed later during the setup process.
+Make note of the names of the three resources listed above as they will be needed later during the setup process.
 
 ### 4. Create the AiiDAlab Terraform deployment directory
 

--- a/copier.yml
+++ b/copier.yml
@@ -5,23 +5,19 @@ _answers_file: .copier-answers.aiidalab-on-azure.yml
 _tasks:
     - cp '{{ _copier_conf.answers_file }}' '{{ hostname }}/.copier-answers.yml'
 
-azurerm_storage_account_name:
-    type: str
-    help: |
-        The name of the storage account that is used to maintain the terraform
-        state.
-
-azurerm_storage_account_rg:
+azurerm_resource_group_name:
     type: str
     default:
-    help: The name of the resource group that contains the storage account.
+    help: The name of the resource group to use.
+
+azurerm_storage_account_name:
+    type: str
+    help: The name of the storage account to use.
 
 azurerm_container_name:
     type: str
     default:
-    help: |
-        The container name used to maintain terraform states within the storage
-        account.
+    help: The name of the container in the storage account to use.
 
 hostname:
     type: str

--- a/template/{{hostname}}/main.tf
+++ b/template/{{hostname}}/main.tf
@@ -1,16 +1,11 @@
-resource "random_pet" "rg-name" {
-  prefix = var.resource_group_name_prefix
-}
-
-resource "azurerm_resource_group" "rg" {
-  name     = random_pet.rg-name.id
-  location = var.resource_group_location
+data "azurerm_resource_group" "default" {
+  name     = "{{ azurerm_resource_group_name }}"
 }
 
 module "cluster" {
   source = "./modules/cluster"
 
-  resource_group_name                 = azurerm_resource_group.rg.name
+  resource_group_name                 = data.azurerm_resource_group.default.name
   cluster_name                        = var.cluster_name
   ssh_public_key                      = var.ssh_public_key
   aks_service_principal_app_id        = var.arm_client_id

--- a/template/{{hostname}}/modules/cluster/analytics.tf
+++ b/template/{{hostname}}/modules/cluster/analytics.tf
@@ -6,14 +6,14 @@ resource "azurerm_log_analytics_workspace" "test" {
   # The WorkSpace name has to be unique across the whole of azure, not just the current subscription/tenant.
   name                = "${var.log_analytics_workspace_name}-${random_id.log_analytics_workspace_name_suffix.dec}"
   location            = var.log_analytics_workspace_location
-  resource_group_name = data.azurerm_resource_group.rg.name
+  resource_group_name = data.azurerm_resource_group.default.name
   sku                 = var.log_analytics_workspace_sku
 }
 
 resource "azurerm_log_analytics_solution" "test" {
   solution_name         = "ContainerInsights"
   location              = azurerm_log_analytics_workspace.test.location
-  resource_group_name   = data.azurerm_resource_group.rg.name
+  resource_group_name   = data.azurerm_resource_group.default.name
   workspace_resource_id = azurerm_log_analytics_workspace.test.id
   workspace_name        = azurerm_log_analytics_workspace.test.name
 

--- a/template/{{hostname}}/modules/cluster/main.tf
+++ b/template/{{hostname}}/modules/cluster/main.tf
@@ -1,11 +1,11 @@
-data "azurerm_resource_group" "rg" {
+data "azurerm_resource_group" "default" {
   name = var.resource_group_name
 }
 
 resource "azurerm_kubernetes_cluster" "k8s" {
   name                = var.cluster_name
-  location            = data.azurerm_resource_group.rg.location
-  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = data.azurerm_resource_group.default.location
+  resource_group_name = data.azurerm_resource_group.default.name
   dns_prefix          = var.dns_prefix
 
   linux_profile {

--- a/template/{{hostname}}/output.tf
+++ b/template/{{hostname}}/output.tf
@@ -1,5 +1,5 @@
 output "resource_group_name" {
-  value = azurerm_resource_group.rg.name
+  value = data.azurerm_resource_group.default.name
 }
 
 output "client_key" {

--- a/template/{{hostname}}/providers.tf
+++ b/template/{{hostname}}/providers.tf
@@ -9,7 +9,7 @@ terraform {
     }
   }
   backend "azurerm" {
-    resource_group_name  = "{{ azurerm_storage_account_rg }}"
+    resource_group_name  = "{{ azurerm_resource_group_name }}"
     storage_account_name = "{{ azurerm_storage_account_name }}"
     container_name       = "{{ azurerm_container_name }}"
     key                  = "{{ hostname }}.terraform.tfstate"

--- a/template/{{hostname}}/variables.tf
+++ b/template/{{hostname}}/variables.tf
@@ -1,8 +1,3 @@
-variable "resource_group_name_prefix" {
-  default     = "rg"
-  description = "Prefix of the resource group name that's combined with a random ID so name is unique in your Azure subscription."
-}
-
 variable "resource_group_location" {
   default     = "eastus"
   description = "Location of the resource group."


### PR DESCRIPTION
Fixes #22 

The copier template requested the user to specify a resource group for the storage account, however, a random resource group would be created and used for other resources, such as the kubernetes cluster. The option specified by the user is now used everywhere where a resource group is required.