### PR TITLE
Increase user server startup time and CPU resources

### DIFF
--- a/template/{{hostname}}/modules/aiidalab/values.yml
+++ b/template/{{hostname}}/modules/aiidalab/values.yml
@@ -29,9 +29,9 @@ singleuser:
     limit: 4G
     guarantee: 2G
   cpu:
-    limit: 2.0
-    guarantee: .5
-  startTimeout: 120
+    limit: 3.0
+    guarantee: 1.0
+  startTimeout: 600
 
 hub:
   config:


### PR DESCRIPTION
Currently the startup of a user server often times out when the kubernetes service takes longer to assign the CPU resources. Increasing the startup timeout to 10 mins is still acceptable and leads to fewer failures.

We also increase the number of guaranteed and the upper limit of CPUs, to make sure each user is able to run a workflow in a reasonable time.