### PR TITLE
Replace deprecated `KUBECONFIG` with `KUBE_CONFIG_PATH`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,9 @@ In order to interact with the Kubernetes cluster, for example to check the statu
    ```
    $ echo "$(terraform output --raw kube_config)" > ./kubeconfig
    ```
-4. Set the `KUBECONFIG` environment variable to point to the kubeconfig file we just created:
+4. Set the `KUBE_CONFIG_PATH` environment variable to point to the kubeconfig file we just created:
    ```
-   $ KUBECONFIG=./kubeconfig
+   $ KUBE_CONFIG_PATH=./kubeconfig
    ```
 5. Finally, check whether you can access the cluster. For example,listing the kubernetes services:
    ```

--- a/template/{{hostname}}/setup-kubeconfig
+++ b/template/{{hostname}}/setup-kubeconfig
@@ -3,6 +3,6 @@
 # Usage: source setup-kubeconfig
 #
 
-export KUBECONFIG=$(realpath ./kubeconfig)
+export KUBE_CONFIG_PATH=$(realpath ./kubeconfig)
 
-echo "$(terraform output --raw kube_config)" > "${KUBECONFIG}"
+echo "$(terraform output --raw kube_config)" > "${KUBE_CONFIG_PATH}"


### PR DESCRIPTION
Fixes #28 

In v2.0.0 of the `helm` provide the `KUBECONFIG` variable has been removed and is replaced by `KUBE_CONFIG_PATH`. See: https://github.com/hashicorp/terraform-provider-helm/blob/main/website/docs/guides/v2-upgrade-guide.markdown