### PR TITLE
fix: skip terraform-fmt on pre-commit.ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 ---
+ci:
+    # skip checks that require terraform to be installed
+    skip: [terraform-fmt]
+    
 repos:
 
     - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 ci:
     # skip checks that require terraform to be installed
     skip: [terraform-fmt]
-    
+
 repos:
 
     - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
The `terraform-fmt` check requires terraform to be installed and therefore fails on CI. While hooks in the `.pre-commit-config.yaml` can install extra dependencies per hook  via the `additional_dependencies` key [1] I don't see a way to install terraform this way currently, and pre-commit.ci does not seem to provide additional mechanisms for installing dependencies.

Note: the alternative route would be to disable pre-commit.ci and switch to running pre-commit on GitHub actions, where we have control over the environment and could install terraform.

[1] https://pre-commit.com/#config-additional_dependencies