### PR TITLE
fix pre-commit on ci

### DIFF
--- a/.github/workflows/ci-style.yaml
+++ b/.github/workflows/ci-style.yaml
@@ -1,25 +1,26 @@
+---
 name: continuous-integration-style
 
-on: 
-  - push
-  - pull_request
+on:
+    - push
+    - pull_request
 
 jobs:
 
-  pre-commit:
+    pre-commit:
 
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
 
-    steps:
-    - uses: actions/checkout@v2
+        steps:
+            - uses: actions/checkout@v2
 
-    - uses: hashicorp/setup-terraform@v2
+            - uses: hashicorp/setup-terraform@v2
 
-    - name: Install system dependencies
-      run: |
-        # tflint
-        curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+            - name: Install system dependencies
+              run: |
+                  # tflint
+                  curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
 
-    - uses: actions/setup-python@v3
-    - uses: pre-commit/action@v3.0.0
+            - uses: actions/setup-python@v3
+            - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/ci-style.yaml
+++ b/.github/workflows/ci-style.yaml
@@ -1,0 +1,25 @@
+name: continuous-integration-style
+
+on: 
+  - push
+  - pull_request
+
+jobs:
+
+  pre-commit:
+
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: hashicorp/setup-terraform@v2
+
+    - name: Install system dependencies
+      run: |
+        # tflint
+        curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 ---
+ci:
+    # skip checks that require terraform to be installed
+    skip: [tflint, terraform-fmt]
+
 repos:
 
     - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/template/{{hostname}}/main.tf
+++ b/template/{{hostname}}/main.tf
@@ -1,5 +1,5 @@
 data "azurerm_resource_group" "default" {
-  name     = "{{ azurerm_resource_group_name }}"
+  name = "{{ azurerm_resource_group_name }}"
 }
 
 module "cluster" {


### PR DESCRIPTION
The `terraform-fmt` check requires terraform to be installed and therefore was failing on pre-commit.ci.
While hooks in the `.pre-commit-config.yaml` can install extra dependencies per hook 
via the `additional_dependencies` key [1] I don't believe terraform can be installed this way currently,
and pre-commit.ci does not seem to provide additional mechanisms for installing dependencies.

We therefore disable those checks on pre-commit.ci and switch to running pre-commit
on GitHub actions, where we have more control over the environment.

Note: Since we are running pre-commit on GitHub actions, one might want to disable pre-commit.ci
for this repository altogether, but it is currently enabled across all repositories of the aiidalab
organization. Disabling it would require enabling pre-commit.ci for each repository individually.

[1] https://pre-commit.com/#config-additional_dependencies